### PR TITLE
Prevent error when passing MSG_MORE to do_sendmsg

### DIFF
--- a/common/include/linux_socket.h
+++ b/common/include/linux_socket.h
@@ -61,6 +61,7 @@ struct mmsghdr {
 #define MSG_TRUNC 0x20
 #define MSG_DONTWAIT 0x40
 #define MSG_NOSIGNAL 0x4000
+#define MSG_MORE     0x8000
 #define MSG_CMSG_CLOEXEC 0x40000000
 
 /* Option levels. */

--- a/libos/src/sys/libos_socket.c
+++ b/libos/src/sys/libos_socket.c
@@ -613,7 +613,7 @@ ssize_t do_sendmsg(struct libos_handle* handle, struct iovec* iov, size_t iov_le
     if (handle->type != TYPE_SOCK) {
         return -ENOTSOCK;
     }
-    if (!WITHIN_MASK(flags, MSG_NOSIGNAL | MSG_DONTWAIT)) {
+    if (!WITHIN_MASK(flags, MSG_NOSIGNAL | MSG_DONTWAIT | MSG_MORE)) {
         return -EOPNOTSUPP;
     }
 


### PR DESCRIPTION
<!--
    Please fill in the following form before submitting this PR
    and ensure that your code follows our coding style guideline:
    https://gramine.readthedocs.io/en/latest/devel/coding-style.html -->

## Description of the changes <!-- (reasons and measures) -->
Ignoring the MSG_MORE flag in do_sendmsg function.
<!--
    If your PR fixes an issue, please remember to add "Fixes #issue_number"
    here, to automatically close it on merge. -->

